### PR TITLE
Allow developers to pass a custom HttpMessageHandler for requests

### DIFF
--- a/lib/SitecoreMobileSDK-PCL/API/Session/IBaseSessionBuilder.cs
+++ b/lib/SitecoreMobileSDK-PCL/API/Session/IBaseSessionBuilder.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+
 namespace Sitecore.MobileSDK.API.Session
 {
   using Sitecore.MobileSDK.API.MediaItem;
@@ -118,6 +120,13 @@ namespace Sitecore.MobileSDK.API.Session
     /// this
     /// </returns>
     IBaseSessionBuilder MediaResizingStrategy(DownloadStrategy resizingFlag);
+
+    /// <summary>
+    /// Sets the HttpMessageHandler to be used for the underlying requests
+    /// </summary>
+    /// <param name="httpMessageHandler">Concrete HttpMessageHandler to be used. (null == default)</param>
+    /// <returns>this</returns>
+    IBaseSessionBuilder MessageHandler(HttpMessageHandler httpMessageHandler);
   }
 }
 

--- a/lib/SitecoreMobileSDK-PCL/ScApiSession.cs
+++ b/lib/SitecoreMobileSDK-PCL/ScApiSession.cs
@@ -41,7 +41,8 @@ namespace Sitecore.MobileSDK
       ISessionConfig config,
       IWebApiCredentials credentials,
       IMediaLibrarySettings mediaSettings,
-      ItemSource defaultSource = null)
+      ItemSource defaultSource = null,
+      HttpMessageHandler httpMessageHandler = null)
     {
       if (null == config)
       {
@@ -61,7 +62,7 @@ namespace Sitecore.MobileSDK
         this.mediaSettings = mediaSettings.MediaSettingsShallowCopy();
       }
 
-      this.httpClient = new HttpClient();
+      this.httpClient = httpMessageHandler == null ? new HttpClient() : new HttpClient(httpMessageHandler);
     }
 
     #region IDisposable

--- a/lib/SitecoreMobileSDK-PCL/Session/SessionBuilder.cs
+++ b/lib/SitecoreMobileSDK-PCL/Session/SessionBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace Sitecore.MobileSDK.Session
+﻿using System.Net.Http;
+
+namespace Sitecore.MobileSDK.Session
 {
   using Sitecore.MobileSDK.API;
   using Sitecore.MobileSDK.API.MediaItem;
@@ -37,7 +39,7 @@
         this.itemSourceAccumulator.Language,
         this.itemSourceAccumulator.VersionNumber);
 
-      var result = new ScApiSession(conf, this.credentials, mediaSettings, itemSource);
+      var result = new ScApiSession(conf, this.credentials, mediaSettings, itemSource, httpMessageHandler);
       return result;
     }
 
@@ -241,6 +243,13 @@
       this.resizingFlag = resizingFlag;
       return this;
     }
+
+    public IBaseSessionBuilder MessageHandler(HttpMessageHandler httpMessageHandler)
+    {
+      this.httpMessageHandler = httpMessageHandler;
+      return this;
+    }
+
     #endregion IAnonymousSessionBuilder
 
     #region State
@@ -254,6 +263,8 @@
 
     private IWebApiCredentials credentials = null;
     private ItemSourcePOD itemSourceAccumulator = new ItemSourcePOD(null, null, null);
+    private HttpMessageHandler httpMessageHandler;
+
     #endregion State
   }
 }


### PR DESCRIPTION
This is useful for:
* testing purposes (mocking)
* native HttpMessageHandler implementations (ModernHttpClient) - as the mono implementation of Httpclient is very slow.

The HttpMessageHandler can be passed optionally, defaulting back to the existing implementation.